### PR TITLE
Apresentar alternativas ao JuliaBox, que não é mais grátis.

### DIFF
--- a/juliatutorialbr-v6-nivel-0/1-INTRODUCAO-LINGUAGEM-PROGRAMACAO-JULIA.ipynb
+++ b/juliatutorialbr-v6-nivel-0/1-INTRODUCAO-LINGUAGEM-PROGRAMACAO-JULIA.ipynb
@@ -23,15 +23,16 @@
     "\n",
     "Julia entrou para o ranking das 50 linguagens de programação mais populares do *TIOBE Index* pela primeira vez em setembro de 2016 e desde então está evoluindo a cada ano. A comunidade apresenta crescimento significativo desde 2012, com mais de 1.200.000 downloads do software básico e mais de 1800 pacotes registrados (são milhares os pacotes não registrados disponíveis no `GitHub`). Em 2015 foi fundada a `Julia Computing` pelos criadores da linguagem para desenvolver produtos profissionais e oferecer serviços personalizados a empresas e pesquisadores. A `Julia Computing` oferece os seguintes produtos:\n",
     "\n",
-    "* **JuliaPro** (https://juliacomputing.com/products/juliapro.html) desenvolvido para profissionais de ciência de dados, engenheiros de software e pesquisadores, `JuliaPro` utiliza o `Juno` que é uma extensão do popular editor `Atom` além de vir com mais de cem pacotes adicionais instalados. `JuliaPro` inclui uma série de recursos poderesos de edição de código. \n",
+    "- Grátis:\n",
+    "  + [**JuliaPro**](https://juliacomputing.com/products/juliapro.html) (recomendado) desenvolvido para profissionais de ciência de dados, engenheiros de software e pesquisadores, `JuliaPro` utiliza o `Juno` que é uma extensão do popular editor `Atom` além de vir com mais de cem pacotes adicionais instalados. `JuliaPro` inclui uma série de recursos poderesos de edição de código. \n",
     "\n",
-    "* **JuliaRun** (https://juliacomputing.com/products/juliarun.html) é para implantação escalonável em produção da linguagem Julia para análise em tempo real e simulações paralelas em larga escala em nuvem pública ou privada. `JuliaRun` fornece funcionalidade para executar e implantar aplicações Julia em escala, incluindo a execução de computação paralela e computação distribuída em clusters privados ou públicos. Apresenta integração com o `AWS`, `Microsoft Azure`, `Google Cloud` e pode ser configurado para rodar com qualquer nuvem privada.\n",
-    "\n",
-    "* **JuliaFin** (https://juliacomputing.com/products/juliafin.html) é um conjunto de pacotes Julia que simplificam o trabalho de modelagem financeira e análise de risco. `JuliaFin` é composto pelos pacotes `Miletus.jl` (é uma poderosa definição de contrato financeiro e linguagem de modelagem, juntamente com um `framework` escrito em Julia), `JuliaBD.jl ()`, `JuliaInXL.jl ()`, além de integragração com `Bloomberg API`.\n",
-    "\n",
-    "* **JuliaDB** (https://juliacomputing.com/products/juliadb.html) é um banco de dados de alto desempenho para computação em memória principal e distribuída. `JuliaDB` permite aproveitar o paralelismo nativo da linguagem Julia em máquinas locais ou cluster, permitindo realizar indexação, filtragem, agregação, aprendizado de máquina e outras funcionalidades, sem a necessidade de carregar conjuntos de dados na memória principal. Os resultados podem ser salvos em armazenamento distribuído. \n",
-    "\n",
-    "* **JuliaBox** (https://juliacomputing.com/products/juliabox.html)  é uma aplicação Web da linguagem Julia que permite utilizar a linguagem diretamente pelo navegador e ainda permite customização de recursos de hardware. `JuliaBox` é uma ótima escolha para aprender a linguagem uma vez que não há necessidade de instalação."
+    "- Pago:\n",
+    "  + [**JuliaRun**](https://juliacomputing.com/products/juliarun.html) é para implantação escalonável em produção da linguagem Julia para análise em tempo real e simulações paralelas em larga escala em nuvem pública ou privada. `JuliaRun` fornece funcionalidade para executar e implantar aplicações Julia em escala, incluindo a execução de computação paralela e computação distribuída em clusters privados ou públicos. Apresenta integração com o `AWS`, `Microsoft Azure`, `Google Cloud` e pode ser configurado para rodar com qualquer nuvem privada.\n",
+    "  \n",
+    "- Alternativas Grátis:\n",
+    "  + Instalar o [**Julia**](https://julialang.org/), depois o [**Atom**](https://atom.io/) e instalar o Plugin [**Juno**](https://atom.io/packages/uber-juno) (mais fácil instalar o **JuliaPro**, que é a mesma coisa, mas sem os pacotes de Julia já instalados.\n",
+    "  \n",
+    "  + Instalar o [**Julia**](https://julialang.org/), depois o [**Jupyter**](https://jupyter.org/install.html) (sua preferência se o *Lab*, o *Notebook* ou ambos), depois instalar o pacote [**IJulia**](https://github.com/JuliaLang/IJulia.jl)."
    ]
   },
   {


### PR DESCRIPTION
Em 01 de Novembro de 2019 o JuliaBox deixou de ser livre, restando 
apenas a versão paga.